### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Angular Booktracker
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.2.4.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.2.4. Please use "npm update" in the frontend folder to load the missing modules like @angular-devkit/build-angular.
 
 ## Development server
 


### PR DESCRIPTION
After Cloning Repo, there is no folder node_modules. Users should use npm update to get the missing ones.